### PR TITLE
test: remove timing flake from perf tests

### DIFF
--- a/tests/AspNetDebugDashboard.Tests/PerformanceTests.cs
+++ b/tests/AspNetDebugDashboard.Tests/PerformanceTests.cs
@@ -52,8 +52,8 @@ public class PerformanceTests
         await middleware.InvokeAsync(context);
         stopwatch.Stop();
 
-        // Assert - Middleware overhead should be reasonable (increased from 100ms to 200ms)
-        stopwatch.ElapsedMilliseconds.Should().BeLessThan(200);
+        // Assert - generous bound: catches hangs, not jitter on loaded CI runners
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(1000);
         _mockStorage.Verify(x => x.StoreRequestAsync(It.IsAny<RequestEntry>()), Times.Once);
     }
 
@@ -81,8 +81,8 @@ public class PerformanceTests
         await middleware.InvokeAsync(context);
         stopwatch.Stop();
 
-        // Assert - Should still be fast even with large body (increased from 50ms to 100ms)
-        stopwatch.ElapsedMilliseconds.Should().BeLessThan(100);
+        // Assert - generous bound: catches hangs, not jitter on loaded CI runners
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(1000);
     }
 
     [Fact]
@@ -120,20 +120,20 @@ public class PerformanceTests
     {
         // Arrange
         _config.IsEnabled = false;
+        var nextCalled = false;
         var middleware = new DebugRequestMiddleware(
-            async context => await Task.Delay(10),
-            _mockOptions.Object, 
+            context => { nextCalled = true; return Task.CompletedTask; },
+            _mockOptions.Object,
             _mockStorage.Object, new DebugContext());
 
         var context = CreateHttpContext();
-        var stopwatch = Stopwatch.StartNew();
 
         // Act
         await middleware.InvokeAsync(context);
-        stopwatch.Stop();
 
-        // Assert - Should be fast when disabled (increased from 20ms to 50ms)
-        stopwatch.ElapsedMilliseconds.Should().BeLessThan(50);
+        // Assert - disabled means pass-through: next runs, nothing is captured.
+        // No wall-clock assertion; timing bounds flake on loaded CI runners.
+        nextCalled.Should().BeTrue();
         _mockStorage.Verify(x => x.StoreRequestAsync(It.IsAny<RequestEntry>()), Times.Never);
     }
 


### PR DESCRIPTION
The v2.0.0 publish run failed on DebugRequestMiddleware_DisabledConfiguration_ShouldHaveNoOverhead — a wall-clock assertion racing Task.Delay on a loaded runner. The disabled-path test now verifies behavior (next runs, nothing stored) instead of timing, and the two remaining tight bounds are loosened to 1s so they catch hangs, not scheduler jitter.
