### PR TITLE
update documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,9 +24,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
- - OS: [e.g. Windows 11, Ubuntu 20.04]
- - .NET Version: [e.g. 7.0.0]
- - AspNetDebugDashboard Version: [e.g. 1.0.0]
+ - OS: [e.g. Windows 11, Ubuntu 24.04]
+ - .NET Version: [e.g. 8.0, 9.0, 10.0]
+ - AspNetDebugDashboard Version: [e.g. 2.0.0]
  - Browser: [e.g. Chrome, Firefox]
 
 **Additional context**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,40 +1,13 @@
-## Description
+## What
 
-Brief description of the changes in this PR.
-
-## Type of Change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Code refactoring
-
-## Testing
-
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] I have tested this change manually
+What does this PR change, and why?
 
 ## Checklist
 
-- [ ] My code follows the project's coding standards
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
+- [ ] `dotnet test` passes
+- [ ] If `dashboard/` changed: ran `npm run build` and committed the regenerated `wwwroot/index.html`
+- [ ] CHANGELOG.md updated if the change is user-visible
 
-## Screenshots (if applicable)
+## Screenshots
 
-Add screenshots to help explain your changes.
-
-## Breaking Changes
-
-Describe any breaking changes and migration steps if applicable.
-
-## Additional Notes
-
-Any additional information or context about the PR.
+For UI changes, before/after screenshots help a lot.

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,12 +74,15 @@ Returns a paginated list of HTTP requests.
 **Query Parameters:**
 - `page` (int): Page number (default: 1)
 - `pageSize` (int): Items per page (default: 50)
+- `search` (string): Match against path and URL (contains)
 - `method` (string): Filter by HTTP method
 - `path` (string): Filter by path (contains)
 - `statusCode` (int): Filter by status code
-- `fromDate` (datetime): Filter from date
-- `toDate` (datetime): Filter to date
-- `sortBy` (string): Sort field (default: "timestamp")
+- `isSuccessful` (bool): `false` returns only 4xx/5xx, `true` only sub-400
+- `minExecutionTime` (int): Only requests at or above this duration in ms
+- `requestId` (string): Exact match on the trace identifier
+- `dateFrom` / `dateTo` (datetime): Time range
+- `sortBy` (string): `timestamp`, `executiontimems`, `statuscode`, `method`, `path` (default: `timestamp`)
 - `sortDescending` (bool): Sort direction (default: true)
 
 **Response:**
@@ -175,9 +178,11 @@ Returns a paginated list of SQL queries.
 - `page` (int): Page number (default: 1)
 - `pageSize` (int): Items per page (default: 50)
 - `search` (string): Search in query text
-- `fromDate` (datetime): Filter from date
-- `toDate` (datetime): Filter to date
-- `sortBy` (string): Sort field (default: "timestamp")
+- `isSlowQuery` (bool): Only queries flagged slow (over `SlowQueryThresholdMs`)
+- `isSuccessful` (bool): Filter by success/failure
+- `requestId` (string): Exact match on the trace identifier
+- `dateFrom` / `dateTo` (datetime): Time range
+- `sortBy` (string): `timestamp` or `executiontimems` (default: `timestamp`)
 - `sortDescending` (bool): Sort direction (default: true)
 
 **Response:**
@@ -443,6 +448,8 @@ public static class DebugLogger
 
 ### IDebugStorage Interface
 
+To swap LiteDB for your own storage, implement `IDebugStorage` and register it before `AddDebugDashboard()`. The full interface (from `Core/Services/IDebugStorage.cs`):
+
 ```csharp
 public interface IDebugStorage : IDisposable
 {
@@ -450,42 +457,37 @@ public interface IDebugStorage : IDisposable
     Task<string> StoreSqlQueryAsync(SqlQueryEntry query);
     Task<string> StoreLogAsync(LogEntry log);
     Task<string> StoreExceptionAsync(ExceptionEntry exception);
-    
+
     Task<PagedResult<RequestEntry>> GetRequestsAsync(DebugFilter filter);
     Task<PagedResult<SqlQueryEntry>> GetSqlQueriesAsync(DebugFilter filter);
     Task<PagedResult<LogEntry>> GetLogsAsync(DebugFilter filter);
     Task<PagedResult<ExceptionEntry>> GetExceptionsAsync(DebugFilter filter);
-    
+
     Task<RequestEntry?> GetRequestAsync(string id);
     Task<SqlQueryEntry?> GetSqlQueryAsync(string id);
     Task<LogEntry?> GetLogAsync(string id);
     Task<ExceptionEntry?> GetExceptionAsync(string id);
-    
+
     Task<DebugStats> GetStatsAsync();
     Task CleanupAsync(int maxEntries);
     Task ClearAllAsync();
+
+    Task<object> GetHealthAsync();
+    Task<object> ExportAllAsync();
+    Task ImportAsync(object data);
+    Task<IEnumerable<object>> SearchAsync(string term, string[] types, int maxResults = 50);
+    Task<object> GetPerformanceMetricsAsync(TimeSpan? timeWindow = null);
+    Task<int> BulkDeleteAsync(string[] ids, string type);
+    Task<int> DeleteOlderThanAsync(DateTime cutoff);
+    Task OptimizeAsync();
+    Task<long> GetDatabaseSizeAsync();
+    Task<int> GetTotalEntriesAsync();
 }
 ```
 
-### Configuration Classes
+### Configuration
 
-```csharp
-public class DebugConfiguration
-{
-    public bool IsEnabled { get; set; } = true;
-    public string DatabasePath { get; set; } = "debug-dashboard.db";
-    public string BasePath { get; set; } = "/_debug";
-    public int MaxEntries { get; set; } = 1000;
-    public bool LogRequestBodies { get; set; } = true;
-    public bool LogResponseBodies { get; set; } = false;
-    public bool LogSqlQueries { get; set; } = true;
-    public bool LogExceptions { get; set; } = true;
-    public bool EnableRealTimeUpdates { get; set; } = true;
-    public List<string> ExcludedPaths { get; set; } = new();
-    public List<string> ExcludedHeaders { get; set; } = new();
-    public int MaxBodySize { get; set; } = 1024 * 1024; // 1MB
-}
-```
+All configuration options and their defaults are documented in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Usage Examples
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,7 +77,7 @@ builder.Services.AddDebugDashboard();
 | `LogResponseBodies` | `bool` | `false` | Capture HTTP response bodies |
 | `LogSqlQueries` | `bool` | `true` | Log Entity Framework queries |
 | `LogExceptions` | `bool` | `true` | Log unhandled exceptions |
-| `EnableDetailedSqlLogging` | `bool` | `true` | Include SQL parameters and execution plans |
+| `EnableDetailedSqlLogging` | `bool` | `true` | Include SQL parameter values in captured queries |
 | `EnableStackTraceCapture` | `bool` | `true` | Capture stack traces for exceptions |
 | `MaxStackTraceDepth` | `int` | `50` | Maximum stack trace depth |
 
@@ -187,39 +187,6 @@ builder.Services.AddDebugDashboard(config =>
     config.LogRequestBodies = false;
     config.LogResponseBodies = false;
 });
-```
-
-### Custom Security Rules
-
-```csharp
-public class SecurityAwareDebugConfiguration : DebugConfiguration
-{
-    public SecurityAwareDebugConfiguration()
-    {
-        // Apply security-first defaults
-        LogRequestBodies = false;
-        LogResponseBodies = false;
-        AllowDataExport = false;
-        AllowDataImport = false;
-        
-        // Enhanced exclusions
-        ExcludedHeaders.AddRange(new[]
-        {
-            "X-Forwarded-For",
-            "X-Real-IP",
-            "X-User-ID",
-            "X-Session-ID"
-        });
-        
-        ExcludedPaths.AddRange(new[]
-        {
-            "/api/admin",
-            "/api/internal",
-            "/health",
-            "/metrics"
-        });
-    }
-}
 ```
 
 ## Performance Optimization
@@ -340,72 +307,8 @@ if (enableDashboard)
 }
 ```
 
-## Validation and Testing
+## Checking the active configuration
 
-### Configuration Validation
+`GET /_debug/api/config` returns the configuration the dashboard is actually running with — useful when appsettings binding and code configuration disagree.
 
-```csharp
-public static class DebugConfigurationValidator
-{
-    public static void Validate(DebugConfiguration config)
-    {
-        if (config.MaxEntries <= 0)
-            throw new ArgumentException("MaxEntries must be greater than 0");
-        
-        if (config.MaxBodySize <= 0)
-            throw new ArgumentException("MaxBodySize must be greater than 0");
-        
-        if (string.IsNullOrEmpty(config.DatabasePath))
-            throw new ArgumentException("DatabasePath cannot be null or empty");
-        
-        if (config.SlowQueryThresholdMs <= 0)
-            throw new ArgumentException("SlowQueryThresholdMs must be greater than 0");
-    }
-}
-```
-
-### Testing Configuration
-
-```csharp
-[Test]
-public void Configuration_Should_Be_Valid()
-{
-    var config = new DebugConfiguration();
-    
-    // Test default values
-    Assert.IsTrue(config.IsEnabled);
-    Assert.AreEqual(1000, config.MaxEntries);
-    Assert.AreEqual("/_debug", config.BasePath);
-    
-    // Test validation
-    Assert.DoesNotThrow(() => DebugConfigurationValidator.Validate(config));
-}
-```
-
-## Best Practices
-
-1. **Security First**: Always review exclusion lists for sensitive data
-2. **Performance**: Monitor the impact on application performance
-3. **Storage**: Consider disk space usage for the database
-4. **Environment**: Use different configurations per environment
-5. **Retention**: Set appropriate retention periods
-6. **Monitoring**: Monitor dashboard usage and performance impact
-
-## Troubleshooting Configuration
-
-### Common Issues
-
-1. **Dashboard Not Loading**: Check `IsEnabled` and environment settings
-2. **No SQL Queries**: Verify EF Core interceptor configuration
-3. **High Memory Usage**: Reduce `MaxEntries` and disable body logging
-4. **Performance Issues**: Increase exclusion lists and reduce logging detail
-
-### Debug Configuration
-
-```csharp
-// Add this endpoint to debug configuration
-app.MapGet("/debug-config", (IOptions<DebugConfiguration> options) => 
-{
-    return Results.Ok(options.Value);
-});
-```
+If something doesn't behave the way the options suggest, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,134 +1,27 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-We release patches for security vulnerabilities for the following versions:
+| Version | Supported |
+| ------- | --------- |
+| 2.0.x   | yes       |
+| 1.0.x   | no        |
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+Don't open a public issue. Use [GitHub's private vulnerability reporting](https://github.com/eladser/AspNetDebugDashboard/security/advisories/new) on this repository and include what you found, how to reproduce it, and what the impact is. You'll get a response within a few days, and credit in the advisory unless you'd rather stay anonymous.
 
-If you discover a security vulnerability, please report it to us responsibly.
+## What this package does and doesn't protect
 
-### How to Report
+This is a development tool. The dashboard has **no authentication** and captures whatever flows through your app: request bodies, headers, SQL with parameter values, stack traces. The protections that exist:
 
-1. **Do not** create a public GitHub issue for security vulnerabilities
-2. Email us at [security@aspnetdebugdashboard.com] or create a private security advisory
-3. Include as much information as possible:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
+- `UseDebugDashboard()` is a no-op outside the Development environment. Enabling it elsewhere requires an explicit `forceEnable: true`.
+- `Authorization` and `Cookie` headers are excluded from capture by default (`ExcludedHeaders`).
+- Response body capture is off by default (`LogResponseBodies = false`).
+- Body capture is size-capped (`MaxBodySize`, default 1 MB).
 
-### What to Expect
+What's on you:
 
-- We will acknowledge your report within 48 hours
-- We will provide a detailed response within 7 days
-- We will keep you informed of our progress
-- We will credit you in our security advisory (unless you prefer to remain anonymous)
-
-## Security Considerations
-
-### Development Environment Only
-
-**Important**: AspNetDebugDashboard is designed for development environments only. By default, it will not run in production environments.
-
-### Data Security
-
-- The dashboard may capture sensitive data (request bodies, headers, SQL queries)
-- Always review the configuration options to exclude sensitive information
-- Use appropriate exclusion lists for headers and paths
-- Consider the security implications of logging request/response bodies
-
-### Network Security
-
-- The dashboard is accessible via HTTP/HTTPS on localhost
-- No authentication is required by default
-- Ensure your development environment is properly secured
-
-### Configuration Security
-
-- Review all configuration options before deployment
-- Use environment-specific configurations
-- Never enable in production without proper security measures
-
-## Security Best Practices
-
-### For Users
-
-1. **Environment Isolation**: Only use in development environments
-2. **Data Exclusion**: Configure exclusions for sensitive data
-3. **Network Access**: Restrict network access to development machines
-4. **Regular Updates**: Keep the package updated to the latest version
-
-### For Contributors
-
-1. **Code Review**: All code changes must be reviewed
-2. **Security Testing**: Test for common security vulnerabilities
-3. **Dependencies**: Keep dependencies updated and secure
-4. **Documentation**: Document security considerations for new features
-
-## Common Security Scenarios
-
-### Sensitive Data Exposure
-
-```csharp
-// Good: Exclude sensitive headers
-builder.Services.AddDebugDashboard(config =>
-{
-    config.ExcludedHeaders = new List<string> 
-    { 
-        "Authorization", 
-        "Cookie", 
-        "X-API-Key",
-        "X-Auth-Token"
-    };
-});
-```
-
-### Path Exclusion
-
-```csharp
-// Good: Exclude sensitive endpoints
-builder.Services.AddDebugDashboard(config =>
-{
-    config.ExcludedPaths = new List<string>
-    {
-        "/_debug",
-        "/admin",
-        "/api/auth",
-        "/api/payments"
-    };
-});
-```
-
-### Body Logging
-
-```csharp
-// Good: Disable body logging for sensitive data
-builder.Services.AddDebugDashboard(config =>
-{
-    config.LogRequestBodies = false;  // Disable if handling sensitive data
-    config.LogResponseBodies = false; // Disable if returning sensitive data
-});
-```
-
-## Vulnerability Disclosure Timeline
-
-1. **Day 0**: Vulnerability reported
-2. **Day 1-2**: Acknowledgment sent to reporter
-3. **Day 3-7**: Initial assessment and response
-4. **Day 8-30**: Development of fix
-5. **Day 31-45**: Testing and validation
-6. **Day 46-60**: Release and public disclosure
-
-## Security Updates
-
-Security updates will be released as patch versions and will be clearly marked in the changelog. We recommend updating immediately when security patches are available.
-
-## Contact
-
-For security-related questions or concerns, please contact us at [security@aspnetdebugdashboard.com].
+- If you force-enable it anywhere reachable by other people, put your own auth in front of the `/_debug` path.
+- Extend `ExcludedHeaders` / `ExcludedPaths` for anything sensitive your app handles (API keys, auth endpoints, payment routes).
+- The LiteDB file (`debug-dashboard.db`) contains everything captured, in plain form. Don't commit it, don't ship it. It's covered by the repo's `.gitignore` pattern, but check your own.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,365 +1,96 @@
-# Troubleshooting Guide
+# Troubleshooting
 
-This guide covers common issues and their solutions when using AspNetDebugDashboard.
+## Dashboard returns 404 at /_debug
 
-## Common Issues
+Work through these in order:
 
-### Dashboard Not Accessible
+1. Both registration calls are present:
 
-#### Problem: Cannot access `/_debug` endpoint
-
-**Possible Causes:**
-1. Middleware not registered
-2. Not running in development environment
-3. Dashboard disabled in configuration
-4. Port conflicts
-
-**Solutions:**
-
-1. **Check Middleware Registration:**
    ```csharp
-   // Ensure this is called
-   app.UseDebugDashboard();
+   builder.Services.AddDebugDashboard();   // services
+   app.UseDebugDashboard();                // middleware
    ```
 
-2. **Environment Check:**
+2. You're running in the **Development** environment. Outside it, `UseDebugDashboard()` does nothing by design. To verify that's the cause:
+
    ```csharp
-   // Force enable for testing
    app.UseDebugDashboard(forceEnable: true);
    ```
 
-3. **Configuration Check:**
+3. Controllers are mapped — the dashboard and its API are controllers, so the app needs `app.MapControllers()` (and `AddDebugDashboard` must run before `Build()`).
+
+4. If you changed `BasePath`, the dashboard is at that path, not `/_debug`.
+
+## SQL queries aren't captured
+
+1. The interceptor must be attached to your DbContext:
+
    ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.IsEnabled = true; // Ensure this is true
-   });
-   ```
-
-4. **Port Conflicts:**
-   - Check if another service is using the same port
-   - Try a different port: `dotnet run --urls="https://localhost:5002"`
-
-### SQL Queries Not Appearing
-
-#### Problem: EF Core queries not being captured
-
-**Possible Causes:**
-1. Interceptor not registered
-2. DbContext not configured correctly
-3. SQL logging disabled
-4. Using raw SQL queries
-
-**Solutions:**
-
-1. **Register Interceptor:**
-   ```csharp
-   builder.Services.AddDbContext<YourDbContext>((sp, options) =>
+   builder.Services.AddDbContext<AppDbContext>((sp, options) =>
    {
        options.UseSqlServer(connectionString);
        options.AddDebugDashboard(sp);
    });
    ```
 
-2. **Alternative Registration:**
-   ```csharp
-   builder.Services.AddDebugDashboardEntityFramework();
-   ```
+   Note the `(sp, options)` overload — the interceptor needs the service provider.
 
-3. **Enable SQL Logging:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.LogSqlQueries = true;
-   });
-   ```
+2. **`UseInMemoryDatabase` produces no SQL.** The EF in-memory provider doesn't go through the relational command pipeline, so there's nothing to intercept. Use SQLite (`UseSqlite("Data Source=dev.db")`) if you want captured queries during local development.
 
-4. **Check EF Core Version:**
-   - Ensure you're using EF Core 7.0+
-   - Update packages if necessary
+3. `LogSqlQueries` must be true (it is by default).
 
-### High Memory Usage
+4. Raw ADO.NET (`SqlCommand` used directly) bypasses EF and isn't captured. Only commands that flow through EF Core's interceptor pipeline are.
 
-#### Problem: Application consuming too much memory
+## Logs don't appear
 
-**Possible Causes:**
-1. Too many entries stored
-2. Large request/response bodies
-3. Cleanup service not running
-4. Memory leaks in storage
+Only entries written through this package's logger are captured — `IDebugLogger` (injected) or the static `DebugLogger`. Output from `ILogger<T>` / Serilog / NLog is **not** picked up; that's a different pipeline.
 
-**Solutions:**
+## Queries/logs aren't attached to their request
 
-1. **Reduce Max Entries:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.MaxEntries = 500; // Reduce from default 1000
-   });
-   ```
+Entries are correlated by `HttpContext.TraceIdentifier` while the request is in flight. Work done outside a request (background services, startup seeding, hosted jobs) is still captured, but lands unattached — you'll see it in the Queries/Logs tabs with no parent request link.
 
-2. **Disable Body Logging:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.LogRequestBodies = false;
-       config.LogResponseBodies = false;
-   });
-   ```
+## The database file is corrupt or won't open
 
-3. **Limit Body Size:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.MaxBodySize = 10 * 1024; // 10KB instead of 1MB
-   });
-   ```
+LiteDB writes a WAL file next to the database: `debug-dashboard-log.db`. Two rules:
 
-4. **Manual Cleanup:**
-   ```csharp
-   // Call cleanup API endpoint
-   POST /_debug/api/cleanup
-   ```
+- If you delete the database manually, **delete both files**. Deleting only `debug-dashboard.db` and leaving the `-log.db` behind corrupts the store on next startup ("page type must be collection page").
+- Don't run two app instances against the same database path. Give each a distinct `DatabasePath`, or accept that the second instance fails to open the file.
 
-### Performance Issues
+When in doubt: stop the app, delete `debug-dashboard.db` *and* `debug-dashboard-log.db`, start again. It's dev data; it's disposable.
 
-#### Problem: Application running slowly
-
-**Possible Causes:**
-1. Too much data being logged
-2. Synchronous operations blocking
-3. Database performance issues
-4. Large SQL queries being logged
-
-**Solutions:**
-
-1. **Exclude Heavy Endpoints:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.ExcludedPaths = new List<string>
-       {
-           "/_debug",
-           "/api/heavy-operation",
-           "/api/file-upload"
-       };
-   });
-   ```
-
-2. **Optimize Database Path:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.DatabasePath = "debug-dashboard.db"; // Use faster storage
-   });
-   ```
-
-3. **Reduce Logging:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.LogSqlQueries = false; // Disable if not needed
-   });
-   ```
-
-### Build Errors
-
-#### Problem: Compilation errors when using the package
-
-**Common Errors:**
-
-1. **Missing Dependencies:**
-   ```
-   Error: Package 'LiteDB' is not found
-   ```
-   **Solution:** Update to latest package version
-
-2. **Target Framework Issues:**
-   ```
-   Error: Package 'AspNetDebugDashboard' is not compatible with net6.0
-   ```
-   **Solution:** Upgrade to .NET 7.0+
-
-3. **Namespace Conflicts:**
-   ```
-   Error: The type 'DebugLogger' exists in both...
-   ```
-   **Solution:** Use fully qualified names
-
-### Runtime Errors
-
-#### Problem: Exceptions during application startup
-
-**Common Errors:**
-
-1. **Service Registration Error:**
-   ```
-   InvalidOperationException: Unable to resolve service for type 'IDebugStorage'
-   ```
-   **Solution:**
-   ```csharp
-   builder.Services.AddDebugDashboard(); // Ensure this is called
-   ```
-
-2. **Database Access Error:**
-   ```
-   UnauthorizedAccessException: Access to the path 'debug-dashboard.db' is denied
-   ```
-   **Solution:**
-   ```csharp
-   builder.Services.AddDebugDashboard(config =>
-   {
-       config.DatabasePath = Path.Combine(Path.GetTempPath(), "debug-dashboard.db");
-   });
-   ```
-
-3. **Middleware Order Error:**
-   ```
-   InvalidOperationException: The middleware order is incorrect
-   ```
-   **Solution:**
-   ```csharp
-   // Ensure correct order
-   app.UseDebugDashboard(); // Should be early in pipeline
-   app.UseRouting();
-   app.UseAuthorization();
-   app.MapControllers();
-   ```
-
-### Browser Issues
-
-#### Problem: Dashboard not loading in browser
-
-**Possible Causes:**
-1. JavaScript disabled
-2. HTTPS certificate issues
-3. Browser cache issues
-4. CORS problems
-
-**Solutions:**
-
-1. **Enable JavaScript:**
-   - Ensure JavaScript is enabled in your browser
-   - Check browser console for errors
-
-2. **HTTPS Certificate:**
-   ```bash
-   dotnet dev-certs https --trust
-   ```
-
-3. **Clear Browser Cache:**
-   - Hard refresh: Ctrl+F5 (Windows) or Cmd+Shift+R (Mac)
-   - Clear browser cache and cookies
-
-4. **Check Network Tab:**
-   - Open browser dev tools
-   - Check Network tab for failed requests
-   - Look for 404 or 500 errors
-
-## Debugging Steps
-
-### 1. Enable Detailed Logging
-
-```json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "AspNetDebugDashboard": "Debug"
-    }
-  }
-}
-```
-
-### 2. Check Configuration
+## Memory or disk usage grows too much
 
 ```csharp
-// Add this to see current configuration
-app.MapGet("/debug-config", (IOptions<DebugConfiguration> config) => 
+builder.Services.AddDebugDashboard(config =>
 {
-    return Results.Ok(config.Value);
+    config.MaxEntries = 500;            // per entry type, oldest trimmed first
+    config.LogRequestBodies = false;    // bodies are the heavy part
+    config.LogResponseBodies = false;
+    config.MaxBodySize = 64 * 1024;     // cap captured body size
+    config.RetentionPeriod = TimeSpan.FromDays(1);
 });
 ```
 
-### 3. Verify Services Registration
+You can also trigger a trim manually (`POST /_debug/api/cleanup`) or wipe everything (`DELETE /_debug/api/clear`, or the Clear button in the dashboard).
+
+## Noisy endpoints flood the capture
+
+Exclude them:
 
 ```csharp
-// Check if services are registered
-app.MapGet("/debug-services", (IServiceProvider services) => 
-{
-    var storage = services.GetService<IDebugStorage>();
-    var logger = services.GetService<IDebugLogger>();
-    
-    return Results.Ok(new 
-    {
-        StorageRegistered = storage != null,
-        LoggerRegistered = logger != null
-    });
-});
+config.ExcludedPaths = new() { "/_debug", "/health", "/metrics", "/api/file-upload" };
 ```
 
-### 4. Test API Endpoints
+Matching is contains-based on the path.
 
-```bash
-# Test if API is accessible
-curl https://localhost:5001/_debug/api/stats
+## Version requirements
 
-# Test configuration endpoint
-curl https://localhost:5001/_debug/api/config
-```
+- .NET 8, 9, or 10
+- EF Core 8+ (matching your target framework) for query capture
+- The 2.x dashboard requires no external resources — if the page loads blank, check the browser console and open an issue with what you see
 
-## Getting Help
+## Still stuck
 
-If you're still experiencing issues:
+Open an issue: https://github.com/eladser/AspNetDebugDashboard/issues
 
-1. **Check Existing Issues:** Search [GitHub issues](https://github.com/eladser/AspNetDebugDashboard/issues)
-2. **Create New Issue:** Use the bug report template
-3. **Provide Details:** Include:
-   - .NET version
-   - Package version
-   - Operating system
-   - Browser version
-   - Minimal reproduction code
-   - Error messages and stack traces
-
-## Diagnostic Information
-
-When reporting issues, please include:
-
-```csharp
-// Add this endpoint to collect diagnostic info
-app.MapGet("/debug-diagnostics", (IServiceProvider services) => 
-{
-    var config = services.GetRequiredService<IOptions<DebugConfiguration>>().Value;
-    var env = services.GetRequiredService<IWebHostEnvironment>();
-    
-    return Results.Ok(new 
-    {
-        Environment = env.EnvironmentName,
-        Configuration = config,
-        DotNetVersion = Environment.Version.ToString(),
-        OS = Environment.OSVersion.ToString(),
-        MachineName = Environment.MachineName,
-        CurrentDirectory = Environment.CurrentDirectory
-    });
-});
-```
-
-## Performance Monitoring
-
-To monitor the dashboard's performance impact:
-
-```csharp
-// Add performance monitoring
-app.Use(async (context, next) =>
-{
-    var sw = System.Diagnostics.Stopwatch.StartNew();
-    await next();
-    sw.Stop();
-    
-    if (sw.ElapsedMilliseconds > 100) // Log slow requests
-    {
-        Console.WriteLine($"Slow request: {context.Request.Path} took {sw.ElapsedMilliseconds}ms");
-    }
-});
-```
+Include the package version, .NET version, what you expected vs. what happened, and a minimal repro if you can. `GET /_debug/api/health` output is useful too — it shows the active configuration and storage state.


### PR DESCRIPTION
Cleans up the docs that were still written for v1 or describing things that don't exist:

- SECURITY.md: pointed at GitHub private vulnerability reporting (the old contact email's domain doesn't exist), supported-versions table now says 2.0.x, replaced the boilerplate with what the package actually does and doesn't protect
- TROUBLESHOOTING.md: rewritten around real failure modes (InMemory provider captures nothing, LiteDB -log.db corruption on partial delete, ILogger output not being captured, unattached background-work entries); dropped the .NET 7 / EF 7 advice and the invented error messages
- API.md: request/query filter params now match the actual DebugFilter binding (dateFrom/dateTo, search, isSuccessful, isSlowQuery, minExecutionTime, requestId), IDebugStorage listing synced with the real interface
- CONFIGURATION.md: removed the made-up validator class and a pointless config-subclass example; fixed the 'execution plans' claim
- Issue/PR templates: trimmed, version examples updated
