### PR TITLE
Fix README images on NuGet listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Versions follow [SemVer](https://semver.org).
 
+## [2.1.1] - 2026-06-14
+
+### Fixed
+- README images (banner, demo gif, screenshots) didn't render on the NuGet listing because they used relative paths and raw HTML. They now use absolute URLs so the listing shows them.
+
 ## [2.1.0] - 2026-06-14
 
 Two additive features. Existing setup is unchanged.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<p align="center">
-  <img src="docs/images/banner.png" alt="" width="780">
-</p>
+![ASP.NET Debug Dashboard](https://raw.githubusercontent.com/eladser/AspNetDebugDashboard/main/docs/images/banner.png)
 
 # ASP.NET Debug Dashboard
 
@@ -14,7 +12,7 @@ Request, SQL query, log, and exception capture for ASP.NET Core, viewable in a d
 
 Everything is stored locally in a LiteDB file. The dashboard ships inside the package as a single self-contained page, so there are no CDN dependencies and it works offline.
 
-![Demo](docs/images/demo.gif)
+![Demo](https://raw.githubusercontent.com/eladser/AspNetDebugDashboard/main/docs/images/demo.gif)
 
 ## Install
 
@@ -25,7 +23,7 @@ dotnet add package AspNetDebugDashboard
 Or in the project file:
 
 ```xml
-<PackageReference Include="AspNetDebugDashboard" Version="2.0.0" />
+<PackageReference Include="AspNetDebugDashboard" Version="2.1.1" />
 ```
 
 Or from the Package Manager Console in Visual Studio:
@@ -107,11 +105,11 @@ Entries written during a request are attached to it, so the request detail shows
 
 Global search (`Ctrl+K`) covers everything. Tables navigate from the keyboard: `j`/`k` rows, `Enter` open, `/` filter, `Esc` close. Queries, logs, and exceptions link back to their parent request.
 
-![Overview](docs/images/overview.png)
+![Overview](https://raw.githubusercontent.com/eladser/AspNetDebugDashboard/main/docs/images/overview.png)
 
-![Request detail](docs/images/request-detail.png)
+![Request detail](https://raw.githubusercontent.com/eladser/AspNetDebugDashboard/main/docs/images/request-detail.png)
 
-![Query detail](docs/images/query-detail.png)
+![Query detail](https://raw.githubusercontent.com/eladser/AspNetDebugDashboard/main/docs/images/query-detail.png)
 
 ## Configuration
 

--- a/src/AspNetDebugDashboard.Mcp/AspNetDebugDashboard.Mcp.csproj
+++ b/src/AspNetDebugDashboard.Mcp/AspNetDebugDashboard.Mcp.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>aspnet-debug-mcp</ToolCommandName>
     <PackageId>AspNetDebugDashboard.Mcp</PackageId>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Elad Sertshuk</Authors>
     <Description>MCP server for AspNetDebugDashboard. Lets coding agents query captured requests, SQL queries, logs, exceptions, and performance from a running dashboard over its REST API.</Description>
     <PackageProjectUrl>https://github.com/eladser/AspNetDebugDashboard</PackageProjectUrl>

--- a/src/AspNetDebugDashboard/AspNetDebugDashboard.csproj
+++ b/src/AspNetDebugDashboard/AspNetDebugDashboard.csproj
@@ -6,9 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>AspNetDebugDashboard</PackageId>
     <Title>ASP.NET Debug Dashboard</Title>
-    <Version>2.1.0</Version>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
-    <FileVersion>2.1.0</FileVersion>
+    <Version>2.1.1</Version>
+    <AssemblyVersion>2.1.1</AssemblyVersion>
+    <FileVersion>2.1.1</FileVersion>
     <Authors>Elad Sertshuk</Authors>
     <Description>Request, SQL query, log, and exception capture for ASP.NET Core, viewable in a dashboard served at /_debug. Inspired by Laravel Telescope. LiteDB storage, EF Core interceptor, zero-config setup.</Description>
     <PackageProjectUrl>https://github.com/eladser/AspNetDebugDashboard</PackageProjectUrl>
@@ -18,7 +18,7 @@
     <PackageTags>aspnetcore;debugging;dashboard;telescope;logging;monitoring;efcore;middleware;developer-tools</PackageTags>
     <RepositoryUrl>https://github.com/eladser/AspNetDebugDashboard</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>2.1.0 adds OpenTelemetry tracing: captured requests and queries are emitted as spans on the "AspNetDebugDashboard" ActivitySource, so adding that source to your tracer forwards them to Aspire or any OTLP backend. There's also a new companion MCP server (AspNetDebugDashboard.Mcp) that lets coding agents query the captured data. Nothing in the existing setup changes.</PackageReleaseNotes>
+    <PackageReleaseNotes>2.1.1 fixes the README images not rendering on the NuGet listing (now absolute URLs). 2.1.0 added OpenTelemetry tracing on the "AspNetDebugDashboard" ActivitySource and a companion MCP server (AspNetDebugDashboard.Mcp) for coding agents.</PackageReleaseNotes>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>


### PR DESCRIPTION
NuGet renders only a markdown subset and resolves no relative paths, so the banner showed as raw HTML text and the gif and screenshots were broken on the package page. Switched all README images to absolute raw.githubusercontent.com URLs in plain markdown, which renders on both NuGet and GitHub. Patch release 2.1.1 so the NuGet listing picks up the corrected README.