### PR TITLE
Add MCP package NuGet badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ The spans carry the request id, status, SQL text, and timing. They cost nothing 
 
 ## MCP server for AI agents
 
+[![NuGet](https://img.shields.io/nuget/v/AspNetDebugDashboard.Mcp.svg?label=AspNetDebugDashboard.Mcp)](https://www.nuget.org/packages/AspNetDebugDashboard.Mcp/)
+[![Downloads](https://img.shields.io/nuget/dt/AspNetDebugDashboard.Mcp.svg)](https://www.nuget.org/packages/AspNetDebugDashboard.Mcp/)
+
 `AspNetDebugDashboard.Mcp` is a separate dotnet tool that exposes the captured data to a coding agent over MCP, so it can read recent requests, the SQL a request ran, recent failures, and performance numbers while it works on your app.
 
 ```bash

--- a/src/AspNetDebugDashboard.Mcp/README.md
+++ b/src/AspNetDebugDashboard.Mcp/README.md
@@ -1,5 +1,9 @@
 # AspNetDebugDashboard.Mcp
 
+[![NuGet](https://img.shields.io/nuget/v/AspNetDebugDashboard.Mcp.svg)](https://www.nuget.org/packages/AspNetDebugDashboard.Mcp/)
+[![Downloads](https://img.shields.io/nuget/dt/AspNetDebugDashboard.Mcp.svg)](https://www.nuget.org/packages/AspNetDebugDashboard.Mcp/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/eladser/AspNetDebugDashboard/blob/main/LICENSE)
+
 An MCP server that lets a coding agent (Claude, Copilot, etc.) read the data [AspNetDebugDashboard](https://github.com/eladser/AspNetDebugDashboard) captures from your running app: recent requests, the SQL a request ran, recent failures, slow queries, performance numbers.
 
 It's a thin client over the dashboard's REST API, so your app needs to be running with the dashboard enabled.


### PR DESCRIPTION
Adds NuGet version and download badges for AspNetDebugDashboard.Mcp: in the MCP section of the main README and at the top of the MCP package's own README.